### PR TITLE
Added centerX & centerY property (equivalent to x & y)

### DIFF
--- a/ViewUtils/ViewUtils.h
+++ b/ViewUtils/ViewUtils.h
@@ -75,6 +75,8 @@
 @property (nonatomic, assign) CGFloat height;
 @property (nonatomic, assign) CGFloat x;
 @property (nonatomic, assign) CGFloat y;
+@property (nonatomic, assign) CGFloat centerX;
+@property (nonatomic, assign) CGFloat centerY;
 
 //bounds accessors
 

--- a/ViewUtils/ViewUtils.m
+++ b/ViewUtils/ViewUtils.m
@@ -373,6 +373,26 @@
     self.center = CGPointMake(self.center.x, y);
 }
 
+- (CGFloat)centerX
+{
+    return self.x;
+}
+
+- (void)setCenterX:(CGFloat)centerX
+{
+    self.x = centerX;
+}
+
+- (CGFloat)centerY
+{
+    return self.y;
+}
+
+- (void)setCenterY:(CGFloat)centerY
+{
+    self.y = centerY;
+}
+
 //bounds accessors
 
 - (CGSize)boundsSize


### PR DESCRIPTION
Hi, I added `centerX` & `centerY` property which were familiar with old Three20's UIView category (sadly it's discontinued now).
I know there are `x` and `y` property already there, 
but they are a little confusing (not origin.x & y) and hard to search from Xcode's search navigator,
so I added as alternatives.

BTW I really like this category and I use in many of my cocoapods library.
Hope you'll merge this one. Cheers!
